### PR TITLE
fix(key): claudeの`className`を小文字表記に修正

### DIFF
--- a/config.py
+++ b/config.py
@@ -82,7 +82,7 @@ def D(exp: str) -> Combo:
 define_modmap({Key.CAPSLOCK: Key.LEFT_CTRL})
 
 define_keymap(
-    re.compile("Claude|LM Studio|Mikutter.rb|Skype|discord"),
+    re.compile("LM Studio|Mikutter.rb|Skype|claude|discord"),
     {
         D("C-m"): [D("Shift-enter"), set_mark(False)],
         D("enter"): [D("enter"), set_mark(False)],
@@ -116,7 +116,7 @@ define_keymap(
 )
 
 define_keymap(
-    re.compile("Claude|LM Studio|Slack|discord|kitty"),
+    re.compile("LM Studio|Slack|claude|discord|kitty"),
     {
         D("C-comma"): D("muhenkan"),
         D("C-dot"): D("henkan"),
@@ -125,7 +125,7 @@ define_keymap(
 )
 
 define_keymap(
-    re.compile("Claude"),
+    re.compile("claude"),
     {
         D("C-o"): D("C-k"),
     },
@@ -137,12 +137,12 @@ define_keymap(
         "|".join(
             [
                 "Chromium",
-                "Claude",
                 "Jdim",
                 "LM Studio",
                 "Mikutter.rb",
                 "Skype",
                 "Slack",
+                "claude",
                 "copyq",
                 "discord",
                 "firefox",


### PR DESCRIPTION
サイレントに、

```
WM_CLASS(STRING) = "claude", "claude"
```

に変更されたっぽい。
